### PR TITLE
Fix #16 - at least subproblem 1 and 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## [unreleased]
+### Added
+- Add an option to rhocall annotate to select 
+
 ## [0.5.2]
 - HW and AZ are flags, set Number appropriately in VCF
 - Use a pyproject.toml, hatchling build

--- a/rhocall/cli.py
+++ b/rhocall/cli.py
@@ -167,6 +167,9 @@ def aggregate(roh, quality_threshold, output, verbose):
 @click.option(
     "--v14/--no-v14", default=True, help="Bcftools v1.4 or newer roh file including RG calls."
 )
+@click.option(
+    "--select-sample", default=None, help="Select sample to use for bcftools v1.4 or newer roh file including RG calls and multiple indidviduals."
+)
 @click.option("bed", "-b", type=click.File("r"), help="BED file with AZ windows.")
 @click.option(
     "--quality_threshold",
@@ -182,7 +185,7 @@ def aggregate(roh, quality_threshold, output, verbose):
 )
 @click.option("-v", "--verbose", count=True, default=2)
 @click.option("--output", "-o", type=click.File("w"), default="-")
-def annotate(vcf, roh, bed, v14, quality_threshold, flag_upd_at_fraction, output, verbose):
+def annotate(vcf, roh, bed, v14, quality_threshold, flag_upd_at_fraction, output, verbose, select_sample):
     """Markup VCF file using rho-calls. Use BED file to mark all variants in AZ
     windows. Alternatively, use a bcftools v>=1.4 file with RG entries to mark
     all vars. With the --no-v14 flag, use an older bcftools v<=1.2 style roh TSV
@@ -222,6 +225,7 @@ def annotate(vcf, roh, bed, v14, quality_threshold, flag_upd_at_fraction, output
             quality_threshold=quality_threshold,
             flag_upd_at_fraction=flag_upd_at_fraction,
             output=output,
+            select_sample=select_sample,
         )
     elif bed and not roh:
         run_annotate(

--- a/rhocall/run_annotate_bcfroh.py
+++ b/rhocall/run_annotate_bcfroh.py
@@ -5,8 +5,12 @@ from rhocall import __version__
 logger = logging.getLogger(__name__)
 
 
-def run_annotate_rg(proband_vcf, bcfroh, quality_threshold, flag_upd_at_fraction, output):
-    """Markup VCF file using rho-call BED file."""
+def run_annotate_rg(proband_vcf, bcfroh, quality_threshold, flag_upd_at_fraction, output, select_sample=None):
+    """Markup VCF file using rho-call BED file.
+
+    If a select_sample is given, only ROH entries for that sample is processed. Otherwise the entries for the
+    first sample encountered is used, even if more are present in the bcftools ROH RG file.
+    """
 
     az_info_header = {
         "ID": "AZ",
@@ -88,7 +92,12 @@ def run_annotate_rg(proband_vcf, bcfroh, quality_threshold, flag_upd_at_fraction
 
         # trust RG entries
         if col[0] == "RG":
+
             sample = str(col[1])
+            if select_sample and sample != select_sample:
+                continue
+            if not select_sample:
+                select_sample = sample
             chrom = str(col[2])
             start = int(col[3])
             end = int(col[4])


### PR DESCRIPTION
- Fix #16, lines 1 and 2

1. Use RG sample to identify which sample the region is for
2. Add an option to the command to select a desired sample to check autozygosity for

Skipping these for now
3. if we invent a use for this it could be revisited, but as it is the INFO tags are supposed to be for all individuals, and this just doesn't seem pressing enough to warrant a FORMAT tag?
4. we could e.g. allow adding multiple sample ids, and update windows to keep only the shared vars. chickening mostly on the metadata (nr of markers, quality etc) being different. And a nagging feeling this would be better done in bcftools - although they seem to have skipped on implementing it in there, instead providing a convenience script to merge regions: https://github.com/samtools/bcftools/blob/develop/misc/run-roh.pl

