### PR TITLE
Bump version to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # ChangeLog
 
-## [unreleased]
+## [0.6]
 ### Added
-- Add an option to rhocall annotate to select 
+- Add an option to rhocall annotate to allow selecting sample for annotation among several in ROH/VCF
 ### Changed
 - Refactor rhocall viz ratio calculation
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Options:
                                   CHR,POS,AZ,QUAL.
   --v14 / --no-v14                Bcftools v1.4 or newer roh file including RG
                                   calls.
+  --select-sample TEXT            Select sample to use for bcftools v1.4 or
+                                  newer roh file including RG calls and
+                                  multiple indidviduals.
   -b FILENAME                     BED file with AZ windows.
   -q, --quality_threshold FLOAT   Minimum quality calls that are imported in
                                   region totals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rhocall"
-version = "0.5.2"
+version = "0.6"
 description = "Call regions of homozygosity and make tentative UPD calls"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }

--- a/rhocall/__init__.py
+++ b/rhocall/__init__.py
@@ -1,1 +1,7 @@
-__version__ = "0.5.1"
+# -*- coding: utf-8 -*-
+try:
+    from importlib.metadata import version
+except ImportError:  # Backport support for importlib metadata on Python 3.7
+    from importlib_metadata import version
+
+__version__ = version("rhocall")


### PR DESCRIPTION
Bump version to 0.6

## [0.6]
### Added
- Add an option to rhocall annotate to allow selecting sample for annotation among several in ROH/VCF
### Changed
- Refactor rhocall viz ratio calculation
### Fixed
- Fixed rhocall viz MNV use flag
